### PR TITLE
Make the 401 errors more explicit.

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,16 +3,16 @@ id: df79860f-ea0e-43a3-8c5a-cacdb6c59895
 management:
   docChecksum: 0a6ab5e8278e14c81f061478fbba3556
   docVersion: "1.0"
-  speakeasyVersion: 1.454.2
-  generationVersion: 2.477.4
-  releaseVersion: 0.2.4
-  configChecksum: a4ea5124726e0d419950633dc14d3f24
+  speakeasyVersion: 1.455.7
+  generationVersion: 2.480.1
+  releaseVersion: 0.3.0
+  configChecksum: e508e2f0a4723362972e5d1cac749683
   published: true
 features:
   python:
     additionalDependencies: 1.0.0
     constsAndDefaults: 1.0.5
-    core: 5.6.11
+    core: 5.7.4
     defaultEnabledRetries: 0.2.0
     devContainers: 3.0.0
     enumUnions: 0.1.0
@@ -20,7 +20,7 @@ features:
     examples: 3.0.0
     globalSecurity: 3.0.2
     globalSecurityCallbacks: 1.0.0
-    globalServerURLs: 3.0.0
+    globalServerURLs: 3.1.0
     methodArguments: 1.0.2
     nameOverrides: 3.0.0
     nullables: 1.0.0

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: "1.0"
   speakeasyVersion: 1.455.7
   generationVersion: 2.480.1
-  releaseVersion: 0.3.0
-  configChecksum: e508e2f0a4723362972e5d1cac749683
+  releaseVersion: 0.2.5
+  configChecksum: 707c4f13b784bbd4e8d6319a5ee631ef
   published: true
 features:
   python:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -16,7 +16,7 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 python:
-  version: 0.2.4
+  version: 0.3.0
   additionalDependencies:
     dev: {}
     main:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -16,7 +16,7 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 python:
-  version: 0.3.0
+  version: 0.2.5
   additionalDependencies:
     dev: {}
     main:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,7 +2,7 @@ speakeasyVersion: 1.455.7
 sources:
     Acuvity-OAS:
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:3cda1e7e42efe6f09b8f9cbc9030487dee2489cf4b22101c478364e1fade232f
+        sourceRevisionDigest: sha256:31fe8aaf0e31f1539716d8d1e3fc89542e587d0d6fb61bbbb44211bb3a990d75
         sourceBlobDigest: sha256:6d31e8c9c15acf9d7e534b5d45c9bcc65cb0045ee5fd63f5ec1da58b7c52a4d5
         tags:
             - latest
@@ -18,10 +18,10 @@ targets:
     python:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:3cda1e7e42efe6f09b8f9cbc9030487dee2489cf4b22101c478364e1fade232f
+        sourceRevisionDigest: sha256:31fe8aaf0e31f1539716d8d1e3fc89542e587d0d6fb61bbbb44211bb3a990d75
         sourceBlobDigest: sha256:6d31e8c9c15acf9d7e534b5d45c9bcc65cb0045ee5fd63f5ec1da58b7c52a4d5
         codeSamplesNamespace: acuvity-oas-python-code-samples
-        codeSamplesRevisionDigest: sha256:7bcff64f4d4b55cd3a7a19299ff75494d014dabd20ea88562148d52e7de8c21c
+        codeSamplesRevisionDigest: sha256:acb403cc6f1e0abc7a153cf867872c1eba783a485c02e5ffe2d6c678448e7716
     typescript:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,8 +1,8 @@
-speakeasyVersion: 1.454.2
+speakeasyVersion: 1.455.7
 sources:
     Acuvity-OAS:
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:a7992b01c5327f71e8c6d7eee1eeab04199df8955420bf58b3ded61d86d62c61
+        sourceRevisionDigest: sha256:3cda1e7e42efe6f09b8f9cbc9030487dee2489cf4b22101c478364e1fade232f
         sourceBlobDigest: sha256:6d31e8c9c15acf9d7e534b5d45c9bcc65cb0045ee5fd63f5ec1da58b7c52a4d5
         tags:
             - latest
@@ -18,10 +18,10 @@ targets:
     python:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:a7992b01c5327f71e8c6d7eee1eeab04199df8955420bf58b3ded61d86d62c61
+        sourceRevisionDigest: sha256:3cda1e7e42efe6f09b8f9cbc9030487dee2489cf4b22101c478364e1fade232f
         sourceBlobDigest: sha256:6d31e8c9c15acf9d7e534b5d45c9bcc65cb0045ee5fd63f5ec1da58b7c52a4d5
         codeSamplesNamespace: acuvity-oas-python-code-samples
-        codeSamplesRevisionDigest: sha256:b55a6b56edaf9dc76fcb992f9cb41049a28f6262ab0216af074fe9566472dd47
+        codeSamplesRevisionDigest: sha256:7bcff64f4d4b55cd3a7a19299ff75494d014dabd20ea88562148d52e7de8c21c
     typescript:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas

--- a/README.md
+++ b/README.md
@@ -225,9 +225,8 @@ with Acuvity(
     res = acuvity.apex.list_analyzers(,
         RetryConfig("backoff", BackoffStrategy(1, 50, 1.1, 100), False))
 
-    if res is not None:
-        # handle response
-        pass
+    # Handle response
+    print(res)
 
 ```
 
@@ -247,9 +246,8 @@ with Acuvity(
 
     res = acuvity.apex.list_analyzers()
 
-    if res is not None:
-        # handle response
-        pass
+    # Handle response
+    print(res)
 
 ```
 <!-- End Retries [retries] -->
@@ -292,9 +290,8 @@ with Acuvity(
 
         res = acuvity.apex.list_analyzers()
 
-        if res is not None:
-            # handle response
-            pass
+        # Handle response
+        print(res)
 
     except models.Elementalerror as e:
         # handle e.data: models.ElementalerrorData
@@ -449,9 +446,8 @@ with Acuvity(
 
     res = acuvity.apex.list_analyzers()
 
-    if res is not None:
-        # handle response
-        pass
+    # Handle response
+    print(res)
 
 ```
 <!-- End Authentication [security] -->

--- a/USAGE.md
+++ b/USAGE.md
@@ -27,9 +27,8 @@ with Acuvity(
         },
     })
 
-    if res is not None:
-        # handle response
-        pass
+    # Handle response
+    print(res)
 ```
 
 </br>
@@ -61,9 +60,8 @@ async def main():
             },
         })
 
-        if res is not None:
-            # handle response
-            pass
+        # Handle response
+        print(res)
 
 asyncio.run(main())
 ```
@@ -86,9 +84,8 @@ with Acuvity(
 
     res = acuvity.apex.list_analyzers()
 
-    if res is not None:
-        # handle response
-        pass
+    # Handle response
+    print(res)
 ```
 
 </br>
@@ -110,9 +107,8 @@ async def main():
 
         res = await acuvity.apex.list_analyzers_async()
 
-        if res is not None:
-            # handle response
-            pass
+        # Handle response
+        print(res)
 
 asyncio.run(main())
 ```

--- a/docs/sdks/apex/README.md
+++ b/docs/sdks/apex/README.md
@@ -29,9 +29,8 @@ with Acuvity(
 
     res = acuvity.apex.list_analyzers()
 
-    if res is not None:
-        # handle response
-        pass
+    # Handle response
+    print(res)
 
 ```
 
@@ -81,9 +80,8 @@ with Acuvity(
         },
     })
 
-    if res is not None:
-        # handle response
-        pass
+    # Handle response
+    print(res)
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "acuvity"
-version = "0.3.0"
+version = "0.2.5"
 description = "Acvuvity Python SDK"
 authors = ["Acuvity, Inc.",]
 readme = "README-PYPI.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "acuvity"
-version = "0.2.4"
+version = "0.3.0"
 description = "Acvuvity Python SDK"
 authors = ["Acuvity, Inc.",]
 readme = "README-PYPI.md"

--- a/src/acuvity/_version.py
+++ b/src/acuvity/_version.py
@@ -3,7 +3,7 @@
 import importlib.metadata
 
 __title__: str = "acuvity"
-__version__: str = "0.2.4"
+__version__: str = "0.3.0"
 
 try:
     if __package__ is not None:

--- a/src/acuvity/_version.py
+++ b/src/acuvity/_version.py
@@ -3,7 +3,7 @@
 import importlib.metadata
 
 __title__: str = "acuvity"
-__version__: str = "0.3.0"
+__version__: str = "0.2.5"
 
 try:
     if __package__ is not None:

--- a/src/acuvity/apex.py
+++ b/src/acuvity/apex.py
@@ -5,7 +5,7 @@ from acuvity import models, utils
 from acuvity._hooks import HookContext
 from acuvity.types import BaseModel, OptionalNullable, UNSET
 from acuvity.utils import get_security_from_env
-from typing import Any, List, Optional, Union, cast
+from typing import Any, List, Mapping, Optional, Union, cast
 
 
 class Apex(BaseSDK):
@@ -17,12 +17,14 @@ class Apex(BaseSDK):
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
+        http_headers: Optional[Mapping[str, str]] = None,
     ) -> List[models.Analyzer]:
         r"""List of all available analyzers.
 
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
+        :param http_headers: Additional headers to set or replace on requests.
         """
         base_url = None
         url_variables = None
@@ -45,6 +47,7 @@ class Apex(BaseSDK):
             request_has_query_params=True,
             user_agent_header="user-agent",
             accept_header_value="application/json",
+            http_headers=http_headers,
             security=self.sdk_configuration.security,
             timeout_ms=timeout_ms,
         )
@@ -101,12 +104,14 @@ class Apex(BaseSDK):
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
+        http_headers: Optional[Mapping[str, str]] = None,
     ) -> List[models.Analyzer]:
         r"""List of all available analyzers.
 
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
+        :param http_headers: Additional headers to set or replace on requests.
         """
         base_url = None
         url_variables = None
@@ -129,6 +134,7 @@ class Apex(BaseSDK):
             request_has_query_params=True,
             user_agent_header="user-agent",
             accept_header_value="application/json",
+            http_headers=http_headers,
             security=self.sdk_configuration.security,
             timeout_ms=timeout_ms,
         )
@@ -188,6 +194,7 @@ class Apex(BaseSDK):
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
+        http_headers: Optional[Mapping[str, str]] = None,
     ) -> models.Scanresponse:
         r"""Processes the scan request.
 
@@ -195,6 +202,7 @@ class Apex(BaseSDK):
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
+        :param http_headers: Additional headers to set or replace on requests.
         """
         base_url = None
         url_variables = None
@@ -222,6 +230,7 @@ class Apex(BaseSDK):
             request_has_query_params=True,
             user_agent_header="user-agent",
             accept_header_value="application/json",
+            http_headers=http_headers,
             security=self.sdk_configuration.security,
             get_serialized_body=lambda: utils.serialize_request_body(
                 request, False, True, "json", Optional[models.Scanrequest]
@@ -286,6 +295,7 @@ class Apex(BaseSDK):
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
+        http_headers: Optional[Mapping[str, str]] = None,
     ) -> models.Scanresponse:
         r"""Processes the scan request.
 
@@ -293,6 +303,7 @@ class Apex(BaseSDK):
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
+        :param http_headers: Additional headers to set or replace on requests.
         """
         base_url = None
         url_variables = None
@@ -320,6 +331,7 @@ class Apex(BaseSDK):
             request_has_query_params=True,
             user_agent_header="user-agent",
             accept_header_value="application/json",
+            http_headers=http_headers,
             security=self.sdk_configuration.security,
             get_serialized_body=lambda: utils.serialize_request_body(
                 request, False, True, "json", Optional[models.Scanrequest]

--- a/src/acuvity/basesdk.py
+++ b/src/acuvity/basesdk.py
@@ -5,7 +5,7 @@ from acuvity import models, utils
 from acuvity._hooks import AfterErrorContext, AfterSuccessContext, BeforeRequestContext
 from acuvity.utils import RetryConfig, SerializedRequestBody, get_body_content
 import httpx
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Mapping, Optional, Tuple
 from urllib.parse import parse_qs, urlparse
 
 
@@ -45,6 +45,7 @@ class BaseSDK:
             Callable[[], Optional[SerializedRequestBody]]
         ] = None,
         url_override: Optional[str] = None,
+        http_headers: Optional[Mapping[str, str]] = None,
     ) -> httpx.Request:
         client = self.sdk_configuration.async_client
         return self.build_request_with_client(
@@ -64,6 +65,7 @@ class BaseSDK:
             timeout_ms,
             get_serialized_body,
             url_override,
+            http_headers,
         )
 
     def build_request(
@@ -85,6 +87,7 @@ class BaseSDK:
             Callable[[], Optional[SerializedRequestBody]]
         ] = None,
         url_override: Optional[str] = None,
+        http_headers: Optional[Mapping[str, str]] = None,
     ) -> httpx.Request:
         client = self.sdk_configuration.client
         return self.build_request_with_client(
@@ -104,6 +107,7 @@ class BaseSDK:
             timeout_ms,
             get_serialized_body,
             url_override,
+            http_headers,
         )
 
     def build_request_with_client(
@@ -126,6 +130,7 @@ class BaseSDK:
             Callable[[], Optional[SerializedRequestBody]]
         ] = None,
         url_override: Optional[str] = None,
+        http_headers: Optional[Mapping[str, str]] = None,
     ) -> httpx.Request:
         query_params = {}
 
@@ -180,6 +185,10 @@ class BaseSDK:
             )
         ):
             headers["content-type"] = serialized_request_body.media_type
+
+        if http_headers is not None:
+            for header, value in http_headers.items():
+                headers[header] = value
 
         timeout = timeout_ms / 1000 if timeout_ms is not None else None
 

--- a/src/acuvity/sdkconfiguration.py
+++ b/src/acuvity/sdkconfiguration.py
@@ -27,9 +27,9 @@ class SDKConfiguration:
     server_defaults: List[Dict[str, str]] = field(default_factory=List)
     language: str = "python"
     openapi_doc_version: str = "1.0"
-    sdk_version: str = "0.2.4"
-    gen_version: str = "2.477.4"
-    user_agent: str = "speakeasy-sdk/python 0.2.4 2.477.4 1.0 acuvity"
+    sdk_version: str = "0.3.0"
+    gen_version: str = "2.480.1"
+    user_agent: str = "speakeasy-sdk/python 0.3.0 2.480.1 1.0 acuvity"
     retry_config: OptionalNullable[RetryConfig] = Field(default_factory=lambda: UNSET)
     timeout_ms: Optional[int] = None
 

--- a/src/acuvity/sdkconfiguration.py
+++ b/src/acuvity/sdkconfiguration.py
@@ -27,9 +27,9 @@ class SDKConfiguration:
     server_defaults: List[Dict[str, str]] = field(default_factory=List)
     language: str = "python"
     openapi_doc_version: str = "1.0"
-    sdk_version: str = "0.3.0"
+    sdk_version: str = "0.2.5"
     gen_version: str = "2.480.1"
-    user_agent: str = "speakeasy-sdk/python 0.3.0 2.480.1 1.0 acuvity"
+    user_agent: str = "speakeasy-sdk/python 0.2.5 2.480.1 1.0 acuvity"
     retry_config: OptionalNullable[RetryConfig] = Field(default_factory=lambda: UNSET)
     timeout_ms: Optional[int] = None
 

--- a/src/acuvity/utils/forms.py
+++ b/src/acuvity/utils/forms.py
@@ -109,13 +109,12 @@ def serialize_multipart_form(
         if not field_metadata:
             continue
 
-        f_name = field.alias if field.alias is not None else name
+        f_name = field.alias if field.alias else name
 
         if field_metadata.file:
             file_fields: Dict[str, FieldInfo] = val.__class__.model_fields
 
             file_name = ""
-            field_name = ""
             content = None
             content_type = None
 
@@ -131,20 +130,15 @@ def serialize_multipart_form(
                 elif file_field_name == "content_type":
                     content_type = getattr(val, file_field_name, None)
                 else:
-                    field_name = (
-                        file_field.alias
-                        if file_field.alias is not None
-                        else file_field_name
-                    )
                     file_name = getattr(val, file_field_name)
 
-            if field_name == "" or file_name == "" or content is None:
+            if file_name == "" or content is None:
                 raise ValueError("invalid multipart/form-data file")
 
             if content_type is not None:
-                files[field_name] = (file_name, content, content_type)
+                files[f_name] = (file_name, content, content_type)
             else:
-                files[field_name] = (file_name, content)
+                files[f_name] = (file_name, content)
         elif field_metadata.json:
             files[f_name] = (
                 None,


### PR DESCRIPTION
Adding a explicit 401 error exception. 

While testing my token had become invalid but, the error return was more generic. 

So, wrapping the error a more explicit 401 error and show it in one line.