### PR TITLE
Fail Acuvity object instantiation if no security was passed

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,9 +1,9 @@
 lockVersion: 2.0.0
 id: 463716ea-2172-44e6-ac63-a7a5b29ba606
 management:
-  docChecksum: c228280ab24af59505327c759fe66d5f
+  docChecksum: 7c335c3dd2980171feb91c16ef4bab7a
   docVersion: "1.0"
-  speakeasyVersion: 1.479.0
+  speakeasyVersion: 1.480.0
   generationVersion: 2.499.0
   releaseVersion: 0.5.5
   configChecksum: 784b11b615a5bb22c4014788402fd370

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.479.0
+speakeasyVersion: 1.480.0
 sources:
     Acuvity-OAS:
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:c094ba26259dac3cdb401f247ac5f9a45f29b731596c7c9bd884909893083d82
-        sourceBlobDigest: sha256:b385e91e0858fc55af8c1907e20cb3153930b6e1fefbf46e7e1e250015891f7c
+        sourceRevisionDigest: sha256:6423547950700c7a3b413df16d2265fa249d9c273955ef4267ad57a0c07b6df8
+        sourceBlobDigest: sha256:cd101e8a39f8de161266ab95e7fe439bd27660a5398fa1a7ab51e6a8e5316ec2
         tags:
             - latest
             - "1.0"
@@ -18,10 +18,10 @@ targets:
     python:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:c094ba26259dac3cdb401f247ac5f9a45f29b731596c7c9bd884909893083d82
-        sourceBlobDigest: sha256:b385e91e0858fc55af8c1907e20cb3153930b6e1fefbf46e7e1e250015891f7c
+        sourceRevisionDigest: sha256:6423547950700c7a3b413df16d2265fa249d9c273955ef4267ad57a0c07b6df8
+        sourceBlobDigest: sha256:cd101e8a39f8de161266ab95e7fe439bd27660a5398fa1a7ab51e6a8e5316ec2
         codeSamplesNamespace: acuvity-oas-python-code-samples
-        codeSamplesRevisionDigest: sha256:4a1d8f759a4b0135db8da38998208e3dd75384c6e0b74609e9c6851b1326e592
+        codeSamplesRevisionDigest: sha256:b16a27b02930320f57e1857b0b96c429cd4dee17634b7624fe011d6efe9da138
     typescript:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas

--- a/apex-openapi.yaml
+++ b/apex-openapi.yaml
@@ -873,7 +873,7 @@ servers:
     url: https://{apex_domain}:{apex_port}
     variables:
       apex_domain:
-        default: apex.acuvity.ai
+        default: api.apex.acuvity.ai
         description: |-
           The Apex domain to use which is specific to each customer and environment.
           This can be determined through the well known Apex info response from the Acuvity backend API.

--- a/src/acuvity/sdk.py
+++ b/src/acuvity/sdk.py
@@ -71,7 +71,7 @@ class Acuvity(BaseSDK):
                 server_url = utils.template_url(server_url, url_params)
         server_defaults: List[Dict[str, str]] = [
             {
-                "apex_domain": apex_domain or "apex.acuvity.ai",
+                "apex_domain": apex_domain or "api.apex.acuvity.ai",
                 "apex_port": apex_port or "443",
             },
         ]

--- a/src/acuvity/sdkextend.py
+++ b/src/acuvity/sdkextend.py
@@ -5,6 +5,7 @@ from acuvity.apexdiscovery import discover_apex
 from acuvity.apexextend import ApexExtended
 from acuvity.sdk import Acuvity
 from acuvity.types import OptionalNullable, UNSET
+from acuvity.utils import get_security_from_env
 from .httpclient import AsyncHttpClient, HttpClient
 from .utils.logger import Logger
 from .utils.retries import RetryConfig
@@ -74,6 +75,9 @@ def __patched_init__(
         timeout_ms=timeout_ms,
         debug_logger=debug_logger,
     )
+
+    if get_security_from_env(self.sdk_configuration.security, models.Security) is None:
+        raise ValueError("No Acuvity AppToken provided.")
 
 # Define the new _init_sdks method
 def __patched_init_sdks(self):


### PR DESCRIPTION
Closes #35 .

- changes the default Apex domain to `api.apex.acuvity.ai`
- fails if `Acuvity()` instantiation does not get a `security` object passed somehow during its initialization process