### PR TITLE
Reworking token check to align with TypeScript SDK

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,7 +2,7 @@ speakeasyVersion: 1.481.1
 sources:
     Acuvity-OAS:
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:fc54e0a5a9e88e968a1ddd4966caa70bf08ff1d7b851bb31dc289fdb9a252b13
+        sourceRevisionDigest: sha256:b7018ae7d7865905689e4a60c2e92292d81b2e3602a07a500fe5da933a889be2
         sourceBlobDigest: sha256:cd101e8a39f8de161266ab95e7fe439bd27660a5398fa1a7ab51e6a8e5316ec2
         tags:
             - latest
@@ -18,10 +18,10 @@ targets:
     python:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:fc54e0a5a9e88e968a1ddd4966caa70bf08ff1d7b851bb31dc289fdb9a252b13
+        sourceRevisionDigest: sha256:b7018ae7d7865905689e4a60c2e92292d81b2e3602a07a500fe5da933a889be2
         sourceBlobDigest: sha256:cd101e8a39f8de161266ab95e7fe439bd27660a5398fa1a7ab51e6a8e5316ec2
         codeSamplesNamespace: acuvity-oas-python-code-samples
-        codeSamplesRevisionDigest: sha256:8c54d53465563b9c5b45bf6c1d49f39b71c16ec26f6f506f4784406a69ccd4d0
+        codeSamplesRevisionDigest: sha256:ee433ca1170285ebff4917333e0c30b478b4d6f8cc0f93f85559c964795d339b
     typescript:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas

--- a/src/acuvity/sdkextend.py
+++ b/src/acuvity/sdkextend.py
@@ -5,7 +5,6 @@ from acuvity.apexdiscovery import discover_apex
 from acuvity.apexextend import ApexExtended
 from acuvity.sdk import Acuvity
 from acuvity.types import OptionalNullable, UNSET
-from acuvity.utils import get_security_from_env
 from .httpclient import AsyncHttpClient, HttpClient
 from .utils.logger import Logger
 from .utils.retries import RetryConfig
@@ -75,9 +74,6 @@ def __patched_init__(
         timeout_ms=timeout_ms,
         debug_logger=debug_logger,
     )
-
-    if get_security_from_env(self.sdk_configuration.security, models.Security) is None:
-        raise ValueError("No Acuvity AppToken provided.")
 
 # Define the new _init_sdks method
 def __patched_init_sdks(self):


### PR DESCRIPTION
This checks for a token already in the `discover_apex` method like in the TypeScript SDK. This makes it easier to reason about our custom code across languages.

Additionally, it adds a check to ensure that the token must not be empty.

Closes #35 